### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/app/src/main/java-gen/net/sxkeji/xddistance/PictureInfoDao.java
+++ b/app/src/main/java-gen/net/sxkeji/xddistance/PictureInfoDao.java
@@ -23,6 +23,7 @@ public class PictureInfoDao extends AbstractDao<PictureInfo, Long> {
      * Can be used for QueryBuilder and for referencing column names.
     */
     public static class Properties {
+        private Properties() {}
         public final static Property Id = new Property(0, Long.class, "id", true, "_id");
         public final static Property Path = new Property(1, String.class, "path", false, "PATH");
         public final static Property Distance = new Property(2, String.class, "distance", false, "DISTANCE");

--- a/app/src/main/java/net/sxkeji/xddistance/utils/Constant.java
+++ b/app/src/main/java/net/sxkeji/xddistance/utils/Constant.java
@@ -5,6 +5,7 @@ package net.sxkeji.xddistance.utils;
  * Created by zhangshixin on 5/6/2016.
  */
 public class Constant {
+    private Constant() {}
     public static final String SP_NAME = "xddistance";
     public static final String SP_HEIGHT = "target_height";
     public static final String FACTOR = "factor";       //距离因子

--- a/app/src/main/java/net/sxkeji/xddistance/utils/FileUtils.java
+++ b/app/src/main/java/net/sxkeji/xddistance/utils/FileUtils.java
@@ -24,6 +24,8 @@ import java.util.Date;
  * Created by zhangshixin on 4/2/2016.
  */
 public class FileUtils {
+    private FileUtils() {}
+
     private static final String TAG = "FileUtils";
     public static final int MEDIA_TYPE_IMG = 1;
     public static final int MEDIA_TYPE_VIDEO = 2;

--- a/app/src/main/java/net/sxkeji/xddistance/utils/SharedPreUtil.java
+++ b/app/src/main/java/net/sxkeji/xddistance/utils/SharedPreUtil.java
@@ -12,6 +12,8 @@ import net.sxkeji.xddistance.BaseApplication;
  */
 public class SharedPreUtil {
 
+    private SharedPreUtil() {}
+
     public static void writeString(String key, String value) {
         getSharedPreferences().edit().putString(key, value).commit();
     }

--- a/greenlib/src/main/java/com/example/GreenDaoGenerator.java
+++ b/greenlib/src/main/java/com/example/GreenDaoGenerator.java
@@ -7,6 +7,9 @@ import de.greenrobot.daogenerator.Entity;
 import de.greenrobot.daogenerator.Schema;
 
 public class GreenDaoGenerator {
+
+    private GreenDaoGenerator() {}
+
     public static void main(String[] args) throws Exception {
         int version = 1;
         String defaultPackage = "net.sxkeji.xddistance";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
