### PR TITLE
Multiple code quality fix-3

### DIFF
--- a/app/src/main/java/net/sxkeji/xddistance/activities/CameraActivity.java
+++ b/app/src/main/java/net/sxkeji/xddistance/activities/CameraActivity.java
@@ -133,7 +133,7 @@ public class CameraActivity extends Activity implements RectControlView.OnRulerH
         mSharedPreferences = getSharedPreferences(Constant.SP_NAME, MODE_PRIVATE);
         targetHeight = mSharedPreferences.getFloat(TARGET_HEIGHT, -1f);
         if (targetHeight != -1f) {
-            etTargetHeight.setText(targetHeight + "");
+            etTargetHeight.setText(Float.toString(targetHeight));
         }else {
             targetHeight = Float.parseFloat(etTargetHeight.getText().toString());
         }
@@ -231,11 +231,7 @@ public class CameraActivity extends Activity implements RectControlView.OnRulerH
      * @return true if has
      */
     private boolean checkHasCameraOrNot(Context context) {
-        if (context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA)) {
-            return true;
-        } else {
-            return false;
-        }
+        return context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA);
     }
 
     Handler spHandler = new Handler() {

--- a/app/src/main/java/net/sxkeji/xddistance/fragments/HomeFragment.java
+++ b/app/src/main/java/net/sxkeji/xddistance/fragments/HomeFragment.java
@@ -70,7 +70,7 @@ public class HomeFragment extends Fragment implements SwipeRefreshLayout.OnRefre
     private void initView() {
 
         ArrayList<PictureInfo> picturesData = getPicturesData();
-        if (picturesData == null || picturesData.size() == 0) {
+        if (picturesData == null || picturesData.isEmpty()) {
             Log.e(TAG, "local db has no pictures!");
             rlEmpty.setVisibility(View.VISIBLE);
         } else {

--- a/app/src/main/java/net/sxkeji/xddistance/utils/FileUtils.java
+++ b/app/src/main/java/net/sxkeji/xddistance/utils/FileUtils.java
@@ -39,11 +39,9 @@ public class FileUtils {
         String savePath = SharedPreUtil.readString(Constant.SAVE_PATH, Constant.DEFAULT__PATH);
         File mediaDir = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES), savePath);
 
-        if (!mediaDir.exists()) {
-            if (!mediaDir.mkdirs()) {
-                Log.e(TAG, "Error: failed to create directory");
-                return null;
-            }
+        if (!mediaDir.exists() && !mediaDir.mkdirs()) {
+            Log.e(TAG, "Error: failed to create directory");
+            return null;
         }
 
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S2131- Primitives should not be boxed just for "String" conversion.
squid:S1126 - Return of boolean expressions should not be wrapped into an "if-then-else" statement. 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness. 
squid:S1066 - Collapsible "if" statements should be merged. 
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S1126
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1066

Please let me know if you have any questions.

Faisal Hameed
